### PR TITLE
Make reset polarity consistent with the verilog implementation

### DIFF
--- a/Library/XUP_LIB/xup_dff_en_reset_1.0/component.xml
+++ b/Library/XUP_LIB/xup_dff_en_reset_1.0/component.xml
@@ -23,7 +23,7 @@
       <spirit:parameters>
         <spirit:parameter>
           <spirit:name>POLARITY</spirit:name>
-          <spirit:value spirit:format="string" spirit:resolve="immediate" spirit:id="BUSIFPARAM_VALUE.SIGNAL_RESET.POLARITY" spirit:choiceRef="choices_0">ACTIVE_LOW</spirit:value>
+          <spirit:value spirit:format="string" spirit:resolve="immediate" spirit:id="BUSIFPARAM_VALUE.SIGNAL_RESET.POLARITY" spirit:choiceRef="choices_0">ACTIVE_HIGH</spirit:value>
         </spirit:parameter>
       </spirit:parameters>
     </spirit:busInterface>

--- a/Library/XUP_LIB/xup_dff_en_reset_vector_1.0/component.xml
+++ b/Library/XUP_LIB/xup_dff_en_reset_vector_1.0/component.xml
@@ -23,7 +23,7 @@
       <spirit:parameters>
         <spirit:parameter>
           <spirit:name>POLARITY</spirit:name>
-          <spirit:value spirit:format="string" spirit:resolve="immediate" spirit:id="BUSIFPARAM_VALUE.SIGNAL_RESET.POLARITY" spirit:choiceRef="choices_0">ACTIVE_LOW</spirit:value>
+          <spirit:value spirit:format="string" spirit:resolve="immediate" spirit:id="BUSIFPARAM_VALUE.SIGNAL_RESET.POLARITY" spirit:choiceRef="choices_0">ACTIVE_HIGH</spirit:value>
         </spirit:parameter>
       </spirit:parameters>
     </spirit:busInterface>

--- a/Library/XUP_LIB/xup_tff_en_reset_1.0/component.xml
+++ b/Library/XUP_LIB/xup_tff_en_reset_1.0/component.xml
@@ -23,7 +23,7 @@
       <spirit:parameters>
         <spirit:parameter>
           <spirit:name>POLARITY</spirit:name>
-          <spirit:value spirit:format="string" spirit:resolve="immediate" spirit:id="BUSIFPARAM_VALUE.SIGNAL_RESET.POLARITY" spirit:choiceRef="choices_0">ACTIVE_LOW</spirit:value>
+          <spirit:value spirit:format="string" spirit:resolve="immediate" spirit:id="BUSIFPARAM_VALUE.SIGNAL_RESET.POLARITY" spirit:choiceRef="choices_0">ACTIVE_HIGH</spirit:value>
         </spirit:parameter>
       </spirit:parameters>
     </spirit:busInterface>

--- a/Library/XUP_LIB/xup_tff_en_reset_vector_1.0/component.xml
+++ b/Library/XUP_LIB/xup_tff_en_reset_vector_1.0/component.xml
@@ -23,7 +23,7 @@
       <spirit:parameters>
         <spirit:parameter>
           <spirit:name>POLARITY</spirit:name>
-          <spirit:value spirit:format="string" spirit:resolve="immediate" spirit:id="BUSIFPARAM_VALUE.SIGNAL_RESET.POLARITY" spirit:choiceRef="choices_0">ACTIVE_LOW</spirit:value>
+          <spirit:value spirit:format="string" spirit:resolve="immediate" spirit:id="BUSIFPARAM_VALUE.SIGNAL_RESET.POLARITY" spirit:choiceRef="choices_0">ACTIVE_HIGH</spirit:value>
         </spirit:parameter>
       </spirit:parameters>
     </spirit:busInterface>


### PR DESCRIPTION
I have changed the component.xml files of the flipflops to make the component instantiated in the block design editor compatible with the verilog description.